### PR TITLE
[DO NOT MERGE] Added support for 'names' elements *with* child elements inside a 'substitute' (e.g. used in APA)

### DIFF
--- a/Sources/CiteProc/v10/Runtime/Processor.cs
+++ b/Sources/CiteProc/v10/Runtime/Processor.cs
@@ -1226,7 +1226,7 @@ namespace CiteProc.v10.Runtime
             }
         }
 
-        protected Result RenderNames(string id, string[] variables, TermName?[] terms, string subsequentAuthorSubstitute, SubsequentAuthorSubstituteRules? subsequentAuthorSubstituteRule, string prefix, string suffix, ExecutionContext c, Parameters p, Func<Parameters, NameParameters> nameParameters, Func<Parameters, EtAlParameters> etAlParameters, Func<Parameters, LabelParameters> labelParameters, Func<NameParameters, EtAlParameters, LabelParameters, Result>[] substitutes)
+        protected Result RenderNames(string id, string[] variables, TermName?[] terms, string subsequentAuthorSubstitute, SubsequentAuthorSubstituteRules? subsequentAuthorSubstituteRule, string prefix, string suffix, bool suppress, ExecutionContext c, Parameters p, Func<Parameters, NameParameters> nameParameters, Func<Parameters, EtAlParameters> etAlParameters, Func<Parameters, LabelParameters> labelParameters, Func<NameParameters, EtAlParameters, LabelParameters, Result>[] substitutes)
         {
             // init
             var np = nameParameters(p);
@@ -1234,7 +1234,7 @@ namespace CiteProc.v10.Runtime
             var lp = labelParameters(p);
 
             // render name groups
-            var result = this.RenderNameGroups(id, variables, terms, subsequentAuthorSubstitute, subsequentAuthorSubstituteRule, prefix, suffix, false, c, p, np, ep, lp);
+            var result = this.RenderNameGroups(id, variables, terms, subsequentAuthorSubstitute, subsequentAuthorSubstituteRule, prefix, suffix, suppress, c, p, np, ep, lp);
 
             // subsitutes?
             if (result.IsEmpty)


### PR DESCRIPTION
With this pull request, CSL `<names>` elements inside a `<substitute>` element are now allowed to have child elements, which is conform the CSL 1.0.1 specs and used in e.g. APA styles.

Also, inside a `<substitute>`, any `<names>` elements without child elements will now inherit name, et-al, label, prefix & suffix from the original `<names>` element (conform https://docs.citationstyles.org/en/stable/specification.html#substitute). 
This fixes 2 tests from the CslTestSuite that failed before: "name_SubstituteOnNamesSpanGroupSpanFail " and "name_SubstituteOnNamesSpanNamesSpanFail".

Note: private method 'CompileNested' became obsolete by this fix, so it has been removed.

Example of a substitute `<names>` element with custom child elements, from apa.csl. In this case, this is used to add `(trans.)` after the translator names in case there is no composer, original-author or author available for a cited song.
![image](https://user-images.githubusercontent.com/70661596/92129605-09357680-ee04-11ea-8611-e99c6da06f91.png)
